### PR TITLE
Fix default config for no-unnamed-types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,13 +21,12 @@ module.exports.rules = requireIndex(__dirname + '/rules');
 module.exports.configs = {
   recommended: {
     rules: {
-      'tcomb/no-unnamed-types': ['error', { enabled: {
-        struct: true,
-        refinement: true,
-        interface: true,
-        tuple: true,
-        enums: true,
-        dict: true
+      'tcomb/no-unnamed-types': ['error', { disabled: {
+        maybe: true,
+        list: true,
+        union: true,
+        intersection: true,
+        func: true
       }}]
     }
   }


### PR DESCRIPTION
This is a fix for the wrong default config introduced by #4 
