### PR TITLE
make checkName safer

### DIFF
--- a/lib/rules/no-unnamed-types.js
+++ b/lib/rules/no-unnamed-types.js
@@ -55,6 +55,10 @@ module.exports = {
     }
 
     function checkName(node) {
+      if (!node.callee.object) {
+        return;
+      }
+
       if (!isTcombCombinatorCall(node) && !isTcombUtilityFunction(node)) {
         return;
       }

--- a/tests/lib/rules/no-unnamed-types.js
+++ b/tests/lib/rules/no-unnamed-types.js
@@ -7,6 +7,9 @@ var ruleTester = new RuleTester();
 ruleTester.run('no-unnamed-types', rule, {
   valid: [
     {
+      code: 'foo(\'bar\')',
+    },
+    {
       code: 't.refinement(t.Number, function () { return true }, \'MyType\')',
     },
     {


### PR DESCRIPTION
It should prevent crashing on stuff like

``` js
debug('app:API');
```

and it is on LOL:
<img width="585" alt="screen shot 2016-05-30 at 10 51 00 pm" src="https://cloud.githubusercontent.com/assets/2643520/15658136/10a3854a-26b9-11e6-9a44-327550523363.png">
