### PR TITLE
#11: more reliable namespace detection (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,61 @@ Then configure the rules you want to use under the rules section.
 * [`no-unnamed-types`](docs/rules/no-unnamed-types.md): disallow types without names
 * [`no-any`](docs/rules/no-any.md): disallow use of `t.Any`
 
+## Namespace detection
+In order to recognize `tcomb` patterns, this plugin detects the name of the imported `tcomb` library.
+
+Example:
+
+```js
+import foo from 'tcomb';
+
+const MyType = foo.Any; // this triggers the no-any rule
+```
+
+In the example above `foo` is identified as the *`tcomb` namespace*;
+
+Both ES2015 modules and `require` are supported, in any of the following forms:
+
+```js
+import anything from 'tcomb';
+import { t } from 'tcomb-react';
+import { t as anything } from 'tcomb-react';
+const anything = require('tcomb');
+const anything = require('tcomb-react').t
+```
+
+`tcomb` can be exported by any module; the recommended configuration (see below), provides
+out-of-the-box support for the following modules:
+
+- `tcomb`
+- `tcomb-validation`
+- `tcomb-form`,
+- `tcomb-form-native`,
+- `tcomb-react`,
+- `redux-tcomb`
+
+If you want your own custom module to be recognized, simply add this to your eslint config:
+
+```json
+{
+  "settings": {
+    "additionalTcombModules": [{
+      "name": "my-module",
+      "defaultExport": true
+    }, {
+      "name": "my-other-module",
+      "defaultExport": false,
+      "exportName": "t"
+    }]
+  }
+}
+```
+
+where:
+- `name` is the module name
+- `defaultExport` indicates whether `tcomb` is exported as the module default
+- `exportName` is the name under which `tcomb` is exported if `defaultExport` is `false`
+
 ## Recommended configuration
 
 This plugin exports a `recommended` configuration that enforce a disciplined tcomb use.

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,9 @@ module.exports.configs = {
         func: true
       }}],
       'tcomb/no-any': 'error'
+    },
+    settings: {
+      tcombModules: require('utils/defaultTcombModules')
     }
   }
 }

--- a/lib/rules/no-any.js
+++ b/lib/rules/no-any.js
@@ -1,11 +1,14 @@
 'use strict';
 
+var tcombNamespace = require('../utils/tcombNamespace');
+
 module.exports = {
 
   create: function (context) {
 
     function checkAny(node) {
-      if (node.object.name === 't' && node.property.name == 'Any') {
+      var t = tcombNamespace(context);
+      if (node.object.name === t && node.property.name == 'Any') {
         context.report({
           node: node,
           message: 'unexpected use of t.Any'

--- a/lib/rules/no-loose-structs.js
+++ b/lib/rules/no-loose-structs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tcombNamespace = require('../utils/tcombNamespace');
+
 module.exports = {
 
   create: function (context) {
@@ -7,9 +9,10 @@ module.exports = {
     var allowExplicit = (context.options[0] || {}).allowExplicit;
 
     // recognize `t.struct(...)` patterns
-    function isTcombStructCall(node) {
+    function isTcombStructCall(node, t) {
       var callee = node.callee;
-      return callee.object.name === 't' && callee.property.name === 'struct'
+      if (!callee.object) return;
+      return callee.object.name === t && callee.property.name === 'struct'
     }
 
     function getStructOptions(node) {
@@ -29,7 +32,9 @@ module.exports = {
     }
 
     function checkTcombStruct(node) {
-      if (isTcombStructCall(node)) {
+      var t = tcombNamespace(context);
+
+      if (isTcombStructCall(node, t)) {
         var structOptions = getStructOptions(node);
 
         // t.struct({})

--- a/lib/rules/no-unnamed-types.js
+++ b/lib/rules/no-unnamed-types.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tcombNamespace = require('../utils/tcombNamespace');
+
 module.exports = {
 
   create: function (context) {
@@ -26,12 +28,12 @@ module.exports = {
       return Object.keys(combinators).indexOf(name) !== -1;
     }
 
-    function isTcombUtilityFunction(node) {
+    function isTcombUtilityFunction(node, t) {
       var object = node.callee.object.object;
       var property = node.callee.object.property;
       if (object && property) {
         return (
-          object.name === 't' &&
+          object.name === t &&
           isTcombCombinator(property.name) &&
           ['of', 'extend'].indexOf(node.callee.property.name) !== -1
         );
@@ -42,8 +44,8 @@ module.exports = {
       return node.callee.object.property.name;
     }
 
-    function isTcombCombinatorCall(node) {
-      return node.callee.object.name === 't' && isTcombCombinator(node.callee.property.name);
+    function isTcombCombinatorCall(node, t) {
+      return node.callee.object.name === t && isTcombCombinator(node.callee.property.name);
     }
 
     function getTcombCombinator(node) {
@@ -55,16 +57,18 @@ module.exports = {
     }
 
     function checkName(node) {
+      var t = tcombNamespace(context);
+
       if (!node.callee.object) {
         return;
       }
 
-      if (!isTcombCombinatorCall(node) && !isTcombUtilityFunction(node)) {
+      if (!isTcombCombinatorCall(node, t) && !isTcombUtilityFunction(node, t)) {
         return;
       }
 
       var combinator;
-      if (isTcombUtilityFunction(node)) {
+      if (isTcombUtilityFunction(node, t)) {
         combinator = getUtilityFunctionCombinator(node);
       } else {
         combinator = getTcombCombinator(node);

--- a/lib/utils/defaultTcombModules.js
+++ b/lib/utils/defaultTcombModules.js
@@ -1,0 +1,21 @@
+module.exports = [{
+  name: 'tcomb',
+  defaultExport: true
+}, {
+  name: 'tcomb-validation',
+  defaultExport: true
+}, {
+  name: 'tcomb-form',
+  defaultExport: true
+}, {
+  name: 'tcomb-form-native',
+  defaultExport: true
+}, {
+  name: 'tcomb-react',
+  defaultExport: false,
+  exportName: 't'
+}, {
+  name: 'redux-tcomb',
+  defaultExport: false,
+  exportName: 't'
+}];

--- a/lib/utils/tcombNamespace.js
+++ b/lib/utils/tcombNamespace.js
@@ -1,0 +1,116 @@
+module.exports = function (context) {
+
+  var config = {
+    tcombModules: [{
+      name: 'tcomb',
+      defaultExport: true
+    }, {
+      name: 'tcomb-validation',
+      defaultExport: true
+    }, {
+      name: 'tcomb-form',
+      defaultExport: true
+    }, {
+      name: 'tcomb-form-native',
+      defaultExport: true
+    }, {
+      name: 'tcomb-react',
+      defaultExport: false,
+      exportName: 't'
+    }, {
+      name: 'redux-tcomb',
+      defaultExport: false,
+      exportName: 't'
+    }]
+  };
+
+  // detected patterns
+  // - [x] var t = require('tcomb')
+  // - [ ] var t = require('tcomb-react').t
+
+  function defaultExportedModules(config) {
+    return config.tcombModules
+    .filter(function (m) { return m.defaultExport })
+    .map(function (m) { return m.name });
+  }
+
+  function namedExportedModules(config) {
+    return config.tcombModules.filter(function (m) { return !m.defaultExport });
+  }
+
+  function detectedDefaultRequire(node) {
+    var calleeName = node.init.callee.name;
+    if (calleeName !== 'require') return;
+    var defaultExports = defaultExportedModules(config);
+    return defaultExports.indexOf(node.init.arguments[0].value) !== -1;
+  }
+
+  function detectedNamedRequire(node) {
+    if (node.init.object.type !== 'CallExpression') return;
+    if (node.init.object.callee.name !== 'require') return;
+    var namedModules = namedExportedModules(config);
+    var namedModule = namedModules.filter(function (m) {
+      return m.name === node.init.object.arguments[0].value;
+    })[0];
+    return node.init.property.name === (namedModule || {}).exportName;
+  }
+
+  function detectedRequire(node) {
+    switch (node.init.type) {
+      case 'CallExpression': return detectedDefaultRequire(node);
+      case 'MemberExpression': return detectedNamedRequire(node);
+    }
+  }
+
+  function findTcombImports(scope, config) {
+    var definitions = Array.from(scope.set.values()).map(function (v) { return v.defs[0] });
+    return definitions.reduce(function (tcomb, def) {
+      if (!def || def.type !== 'ImportBinding') return;
+      if (def.parent.type !== 'ImportDeclaration') return;
+      switch (def.node.type) {
+        case 'ImportDefaultSpecifier':
+          var defaultExports = defaultExportedModules(config);
+          if (defaultExports.indexOf(def.parent.source.value) !== -1) {
+            return { name: def.parent.source.value }
+          };
+        case 'ImportSpecifier':
+          var namedModules = namedExportedModules(config);
+          return namedModules.reduce(function (tcomb, m) {
+            if (tcomb) return tcomb;
+            var specifier = def.parent.specifiers.filter(function (s) {
+              return s.imported.name === m.exportName;
+            })[0];
+            if (specifier) {
+              return { name: specifier.local.name };
+            }
+          }, null);
+      }
+    }, null);
+  }
+
+  function findInScope(scope, config) {
+    var x = findTcombImports(scope, config);
+    if (x) return x;
+
+    var y = scope.variables.filter(function (vv) {
+      var defnNode = (vv.defs[0] || {}).node;
+      if (!defnNode || !defnNode.init) return;
+      return detectedRequire(defnNode);
+    })[0];
+    if (y) return y;
+    if (!scope.upper) return;
+    return findInScope(scope.upper, config);
+  }
+
+  var tcombDefinition = findInScope(context.getScope(), config);
+  if (tcombDefinition && tcombDefinition.name) {
+    return tcombDefinition.name;
+  } else {
+    context.report({
+      message: 'unable to find tcomb import or require',
+      loc: {
+        line: 1
+      }
+    });
+  }
+};

--- a/lib/utils/tcombNamespace.js
+++ b/lib/utils/tcombNamespace.js
@@ -1,32 +1,10 @@
 module.exports = function (context) {
 
+  var settings = context.settings || {};
+  var tcombModules = (settings.tcombModules || []).concat(settings.additionalTcombModules || []);
   var config = {
-    tcombModules: [{
-      name: 'tcomb',
-      defaultExport: true
-    }, {
-      name: 'tcomb-validation',
-      defaultExport: true
-    }, {
-      name: 'tcomb-form',
-      defaultExport: true
-    }, {
-      name: 'tcomb-form-native',
-      defaultExport: true
-    }, {
-      name: 'tcomb-react',
-      defaultExport: false,
-      exportName: 't'
-    }, {
-      name: 'redux-tcomb',
-      defaultExport: false,
-      exportName: 't'
-    }]
+    tcombModules: tcombModules
   };
-
-  // detected patterns
-  // - [x] var t = require('tcomb')
-  // - [ ] var t = require('tcomb-react').t
 
   function defaultExportedModules(config) {
     return config.tcombModules

--- a/lib/utils/tcombNamespace.js
+++ b/lib/utils/tcombNamespace.js
@@ -47,6 +47,7 @@ module.exports = function (context) {
       if (def.parent.type !== 'ImportDeclaration') return;
       switch (def.node.type) {
         case 'ImportDefaultSpecifier':
+        case 'ImportNamespaceSpecifier':
           var defaultExports = defaultExportedModules(config);
           if (defaultExports.indexOf(def.parent.source.value) !== -1) {
             return { name: def.parent.source.value }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
+    "babel-eslint": "^6.0.4",
     "eslint": "~2.6.0",
     "mocha": "^2.5.3"
   },

--- a/tests/lib/RuleTester.js
+++ b/tests/lib/RuleTester.js
@@ -1,0 +1,9 @@
+var RuleTester = require('eslint').RuleTester;
+
+RuleTester.setDefaultConfig({
+  settings: {
+    tcombModules: require('../../lib/utils/defaultTcombModules')
+  }
+});
+
+module.exports = RuleTester;

--- a/tests/lib/rules/no-any.js
+++ b/tests/lib/rules/no-any.js
@@ -7,21 +7,40 @@ var ruleTester = new RuleTester();
 ruleTester.run('no-any', rule, {
   valid: [
     {
-      code: 't.struct({ bar: t.String })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({ foo: t.String });'
+      ].join('\n'),
+    },
+    {
+      code: [
+        'import t from "tcomb"',
+        't.struct({ foo: t.String });'
+      ].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 
   invalid: [
     {
-      code: 't.struct({ foo: t.Any })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({ foo: t.Any });'
+      ].join('\n'),
       errors: [ { message: 'unexpected use of t.Any' } ],
     },
     {
-      code: 't.maybe(t.Any)',
+      code: [
+        'var t = require("tcomb");',
+        't.maybe(t.Any);'
+      ].join('\n'),
       errors: [ { message: 'unexpected use of t.Any' } ],
     },
     {
-      code: 't.Any',
+      code: [
+        'var t = require("tcomb");',
+        't.Any;'
+      ].join('\n'),
       errors: [ { message: 'unexpected use of t.Any' } ],
     }
   ]

--- a/tests/lib/rules/no-any.js
+++ b/tests/lib/rules/no-any.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var rule = require('../../../lib/rules/no-any.js');
-var RuleTester = require('eslint').RuleTester;
+var RuleTester = require('../RuleTester');
 
 var ruleTester = new RuleTester();
 ruleTester.run('no-any', rule, {

--- a/tests/lib/rules/no-loose-structs.js
+++ b/tests/lib/rules/no-loose-structs.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var rule = require('../../../lib/rules/no-loose-structs.js');
-var RuleTester = require('eslint').RuleTester;
+var RuleTester = require('../RuleTester');
 
 var ruleTester = new RuleTester();
 ruleTester.run('no-loose-structs', rule, {

--- a/tests/lib/rules/no-loose-structs.js
+++ b/tests/lib/rules/no-loose-structs.js
@@ -7,28 +7,42 @@ var ruleTester = new RuleTester();
 ruleTester.run('no-loose-structs', rule, {
   valid: [
     {
-      code: 't.struct({}, { strict: true })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({}, { strict: true })'
+      ].join('\n')
     },
     {
-      code: 't.struct({}, { strict: false })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({}, { strict: false })'
+      ].join('\n'),
       options: [{ allowExplicit: true }]
     }
   ],
 
   invalid: [
     {
-      code: 't.struct({})',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({})'
+      ].join('\n'),
       errors: [ { message: 'use of loose tcomb structs is forbidden. Add option \'{ strict: true }\'' } ],
     },
     {
-      code: 't.struct({})',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({})'
+      ].join('\n'),
       errors: [ { message: 'use of loose tcomb structs is forbidden. Add option \'{ strict: true }\'' } ],
       options: [{ allowExplicit: true }]
     },
     {
-      code: 't.struct({}, { strict: false })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({}, { strict: false })'
+      ].join('\n'),
       errors: [ { message: 'use of loose tcomb structs is forbidden' } ],
     }
   ]
 });
-

--- a/tests/lib/rules/no-unnamed-types.js
+++ b/tests/lib/rules/no-unnamed-types.js
@@ -7,131 +7,227 @@ var ruleTester = new RuleTester();
 ruleTester.run('no-unnamed-types', rule, {
   valid: [
     {
-      code: 'foo(\'bar\')',
+      code: [
+        'var t = require("tcomb");',
+        'foo(\'bar\')'
+      ].join('\n')
     },
     {
-      code: 't.refinement(t.Number, function () { return true }, \'MyType\')',
+      code: [
+        'var t = require("tcomb");',
+        't.refinement(t.Number, function () { return true }, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.enums({ IT: \'IT\' }, \'MyType\')',
+      code: [
+        'var t = require("tcomb");',
+        't.enums({ IT: \'IT\' }, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.enums.of([\'IT\'], \'MyType\')',
+      code: [
+        'var t = require("tcomb");',
+        't.enums.of([\'IT\'], \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.maybe(t.String, \'MyType\')',
+      code: [
+        'var t = require("tcomb");',
+        't.maybe(t.String, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.struct({}, \'MyType\')',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({}, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.struct({}, { name: \'MyType\' })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({}, { name: \'MyType\' })'
+      ].join('\n')
     },
     {
-      code: 'Type.extend({}, \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        'Type.extend({}, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.struct.extend([Type, {}], \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.struct.extend([Type, {}], \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.tuple([t.Number, t.Number], \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.tuple([t.Number, t.Number], \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.list(t.Number, \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.list(t.Number, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.dict(t.Number, t.String, \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.dict(t.Number, t.String, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.union([A, B], \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.union([A, B], \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.intersection([A, B], \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.intersection([A, B], \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.interface({}, \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.interface({}, \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.interface.extend([Type, {}], \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.interface.extend([Type, {}], \'MyType\')'
+      ].join('\n')
     },
     {
-      code: 't.func([A], B, \'MyType\')'
+      code: [
+        'var t = require("tcomb");',
+        't.func([A], B, \'MyType\')'
+      ].join('\n')
     }
   ],
 
   invalid: [
     {
-      code: 't.refinement(t.Number, function () { return true })',
+      code: [
+        'var t = require("tcomb");',
+        't.refinement(t.Number, function () { return true })'
+      ].join('\n'),
       errors: [ { message: 'refinement must have a name' } ],
       options: [{ enabled: { refinement: true } }]
     },
     {
-      code: 't.enums({ IT: \'IT\' })',
+      code: [
+        'var t = require("tcomb");',
+        't.enums({ IT: \'IT\' })'
+      ].join('\n'),
       errors: [ { message: 'enums must have a name' } ],
       options: [{ enabled: { enums: true } }]
     },
     {
-      code: 't.enums.of({ IT: \'IT\' })',
+      code: [
+        'var t = require("tcomb");',
+        't.enums.of({ IT: \'IT\' })'
+      ].join('\n'),
       errors: [ { message: 'enums must have a name' } ],
       options: [{ enabled: { enums: true } }]
     },
     {
-      code: 't.maybe(t.String)',
+      code: [
+        'var t = require("tcomb");',
+        't.maybe(t.String)'
+      ].join('\n'),
       errors: [ { message: 'maybe must have a name' } ],
       options: [{ enabled: { maybe: true } }]
     },
     {
-      code: 't.struct({})',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({})'
+      ].join('\n'),
       errors: [ { message: 'struct must have a name' } ],
       options: [{ enabled: { struct: true } }]
     },
     {
-      code: 't.struct({}, { strict: true })',
+      code: [
+        'var t = require("tcomb");',
+        't.struct({}, { strict: true })'
+      ].join('\n'),
       errors: [ { message: 'struct must have a name' } ],
       options: [{ enabled: { struct: true } }]
     },
     {
-      code: 't.struct.extend([Type, {}])',
+      code: [
+        'var t = require("tcomb");',
+        't.struct.extend([Type, {}])'
+      ].join('\n'),
       errors: [ { message: 'struct must have a name' } ],
       options: [{ enabled: { struct: true } }]
     },
     {
-      code: 't.tuple([t.Number, t.Number])',
+      code: [
+        'var t = require("tcomb");',
+        't.tuple([t.Number, t.Number])'
+      ].join('\n'),
       errors: [ { message: 'tuple must have a name' } ],
       options: [{ enabled: { tuple: true } }]
     },
     {
-      code: 't.list(t.Number)',
+      code: [
+        'var t = require("tcomb");',
+        't.list(t.Number)'
+      ].join('\n'),
       errors: [ { message: 'list must have a name' } ],
       options: [{ enabled: { list: true } }]
     },
     {
-      code: 't.dict(t.Number, t.String)',
+      code: [
+        'var t = require("tcomb");',
+        't.dict(t.Number, t.String)'
+      ].join('\n'),
       errors: [ { message: 'dict must have a name' } ],
       options: [{ enabled: { dict: true } }]
     },
     {
-      code: 't.union([A, B])',
+      code: [
+        'var t = require("tcomb");',
+        't.union([A, B])'
+      ].join('\n'),
       errors: [ { message: 'union must have a name' } ],
       options: [{ enabled: { union: true } }]
     },
     {
-      code: 't.intersection([A, B])',
+      code: [
+        'var t = require("tcomb");',
+        't.intersection([A, B])'
+      ].join('\n'),
       errors: [ { message: 'intersection must have a name' } ],
       options: [{ enabled: { intersection: true } }]
     },
     {
-      code: 't.interface({})',
+      code: [
+        'var t = require("tcomb");',
+        't.interface({})'
+      ].join('\n'),
       errors: [ { message: 'interface must have a name' } ],
       options: [{ enabled: { interface: true } }]
     },
     {
-      code: 't.interface.extend([Type, {}])',
+      code: [
+        'var t = require("tcomb");',
+        't.interface.extend([Type, {}])'
+      ].join('\n'),
       errors: [ { message: 'interface must have a name' } ],
       options: [{ enabled: { interface: true } }]
     },
     {
-      code: 't.func([A], B )',
+      code: [
+        'var t = require("tcomb");',
+        't.func([A], B )'
+      ].join('\n'),
       errors: [ { message: 'func must have a name' } ],
       options: [{ enabled: { func: true } }]
     }

--- a/tests/lib/rules/no-unnamed-types.js
+++ b/tests/lib/rules/no-unnamed-types.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var rule = require('../../../lib/rules/no-unnamed-types.js');
-var RuleTester = require('eslint').RuleTester;
+var RuleTester = require('../RuleTester');
 
 var ruleTester = new RuleTester();
 ruleTester.run('no-unnamed-types', rule, {


### PR DESCRIPTION
Issue #11 

This currently detects these patterns

``` js
import anything from 'tcomb';
import { t } from 'tcomb-react';
import { t as anything } from 'tcomb-react';
const anything = require('tcomb');
const anything = require('tcomb-react').t
```

Some modules are provided by default when using the recommended configuration:
- `tcomb`
- `tcomb-validation`
- `tcomb-form`,
- `tcomb-form-native`,
- `tcomb-react`,
- `redux-tcomb`
